### PR TITLE
Add Styleguidekit Assets Fork

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
 		"php": ">=5.4",
 		"pattern-lab/core": "^2.0.0",
 		"pattern-lab/patternengine-twig": "^2.0.0",
-    "pattern-lab/styleguidekit-assets-default": "^3.0.0",
+		"pattern-lab/styleguidekit-assets-default": "^3.0.0",
 		"pattern-lab/styleguidekit-twig-default": "^3.0.0"
 	},
 	"scripts": {

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,10 @@
     },
     {
       "type": "vcs",
+      "url": "https://github.com/drupal-pattern-lab/styleguidekit-assets-default"
+    },
+    {
+      "type": "vcs",
       "url": "https://github.com/drupal-pattern-lab/styleguidekit-twig-default"
     }
   ],
@@ -41,6 +45,7 @@
 		"php": ">=5.4",
 		"pattern-lab/core": "^2.0.0",
 		"pattern-lab/patternengine-twig": "^2.0.0",
+    "pattern-lab/styleguidekit-assets-default": "^3.0.0",
 		"pattern-lab/styleguidekit-twig-default": "^3.0.0"
 	},
 	"scripts": {


### PR DESCRIPTION
Add in styleguidekit-assets-default dependency fork so everything's pointing at the drupal-pattern-lab org in one place. Corresponds with https://github.com/drupal-pattern-lab/styleguidekit-twig-default/pull/1