### PR TITLE
Pointing dependencies to our forks

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ The Standard Edition for Twig gives developers and designers a clean and stable 
 
 The Standard Edition for Twig comes with the following components:
 
-* `pattern-lab/core`: [GitHub](https://github.com/drupal-pattern-lab/patternlab-php-core)
-* `pattern-lab/patternengine-twig`: [GitHub](https://github.com/drupal-pattern-lab/patternengine-php-twig)
-* `pattern-lab/styleguidekit-assets-default`: [GitHub](https://github.com/drupal-pattern-lab/styleguidekit-assets-default)
-* `pattern-lab/styleguidekit-twig-default`: [GitHub](https://github.com/drupal-pattern-lab/styleguidekit-twig-default)
+* `drupal-pattern-lab/core`: [GitHub](https://github.com/drupal-pattern-lab/patternlab-php-core)
+* `drupal-pattern-lab/patternengine-twig`: [GitHub](https://github.com/drupal-pattern-lab/patternengine-php-twig)
+* `drupal-pattern-lab/styleguidekit-assets-default`: [GitHub](https://github.com/drupal-pattern-lab/styleguidekit-assets-default)
+* `drupal-pattern-lab/styleguidekit-twig-default`: [GitHub](https://github.com/drupal-pattern-lab/styleguidekit-twig-default)
 
 ## Installing
 

--- a/composer.json
+++ b/composer.json
@@ -15,37 +15,19 @@
 	],
 	"support": {
 		"issues":         "https://github.com/drupal-pattern-lab/edition-php-twig-standard/issues",
-		"source":         "https://github.com/drupalpattern-lab/edition-php-twig-standard/releases"
+		"source":         "https://github.com/drupal-pattern-lab/edition-php-twig-standard/releases"
 	},
 	"autoload": {
 		"psr-0": {
 			"PatternLab":   "core/src/"
 		}
 	},
-  "repositories": [
-    {
-      "type": "vcs",
-      "url": "https://github.com/drupal-pattern-lab/patternlab-php-core"
-    },
-    {
-      "type": "vcs",
-      "url": "https://github.com/drupal-pattern-lab/patternengine-php-twig"
-    },
-    {
-      "type": "vcs",
-      "url": "https://github.com/drupal-pattern-lab/styleguidekit-assets-default"
-    },
-    {
-      "type": "vcs",
-      "url": "https://github.com/drupal-pattern-lab/styleguidekit-twig-default"
-    }
-  ],
 	"require": {
 		"php": ">=5.4",
-		"pattern-lab/core": "^2.0.0",
-		"pattern-lab/patternengine-twig": "^2.0.0",
-		"pattern-lab/styleguidekit-assets-default": "^3.0.0",
-		"pattern-lab/styleguidekit-twig-default": "^3.0.0"
+		"drupal-pattern-lab/core": "^2.0.0",
+		"drupal-pattern-lab/patternengine-twig": "^2.0.0",
+		"drupal-pattern-lab/styleguidekit-assets-default": "^3.0.0",
+		"drupal-pattern-lab/styleguidekit-twig-default": "^3.0.0"
 	},
 	"scripts": {
 		"post-install-cmd": [


### PR DESCRIPTION
All the dependencies required have been registered and this swaps out requiring `pattern-lab/core` for `drupal-pattern-lab/core` etc.

However, when I run `composer create-project` in the repo; I still end up with `vendor/pattern-lab/core` – I believe that is b/c some of the dependencies haven't had a release under the new name.... I think; not sure.

We've got to get this branch so that when you run `composer create-project` in the repo; all the dependencies are from us.