### PR TITLE
Ensuring initial config is not overwritten later

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,10 @@
 			"starterKitSuggestions": [
 				"drupal-pattern-lab/starterkit-twig-demo",
 				"drupal-pattern-lab/starterkit-twig-base"
-			]
+			],
+      "config": {
+        "overrideConfig": false
+      }
 		}
 	}
 }


### PR DESCRIPTION
Without this change, this can happen:

1. Create project using this, which creates the PL config file with a setting of `overrideConfig: q`
2. Make changes to config file.
3. Someone else clones and runs `composer install --no-interaction`
4. Any plugins with a default config will overwrite the config

This fixes that scenario. After this is merged, it'd be a good idea to do a patch release.